### PR TITLE
Remove php7 from allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
     - TEST_COMMAND="composer test"
 
 matrix:
-  allow_failures:
-    - php: 7.0
   fast_finish: true
   include:
     - php: 5.4


### PR DESCRIPTION
As php 7 is out we should support it